### PR TITLE
Save selected locale to AppStorage

### DIFF
--- a/LoreOfLegends/ViewModels/ChampionViewModel.swift
+++ b/LoreOfLegends/ViewModels/ChampionViewModel.swift
@@ -6,12 +6,13 @@
 //
 
 import Foundation
+import SwiftUI
 
 @MainActor final class ChampionViewModel: ObservableObject {
+    @AppStorage("currentLocale") var currentLocale: String = "en_US"
     @Published var champions: [Champion] = []
     @Published var locales: [String] = []
     @Published var selectedChampion: Champion?
-    @Published var currentLocale = "en_US"
     @Published var searchingQuery = ""
     @Published var state: State = .loading
     @Published var currentPage = 1


### PR DESCRIPTION
In this PR, I have changed `currentLocal` or in other words currently selected language, by user from being `@Published` property to be saved in `@AppStorage`, so the changes are persistent when user closes the app.